### PR TITLE
Fix integer-overflow crash in qrng_range32/qrng_range64

### DIFF
--- a/src/quantum_rng/quantum_rng.c
+++ b/src/quantum_rng/quantum_rng.c
@@ -401,20 +401,28 @@ int32_t qrng_range32(qrng_ctx *ctx, int32_t min, int32_t max) {
     if (!ctx || min > max) {
         return max;
     }
-    
-    uint32_t range = (uint32_t)(max - min + 1);
-    if (range == 0) {
-        return max;
+
+    /* Span in [1, 2^32]. Compute in 64-bit signed so (max - min + 1) can
+       never overflow: the original int32 form is signed-overflow UB at the
+       full span, and at -O2 the compiler then PROVES range != 0 and deletes
+       the (range == 0) guard below -- leaving r % 0 (SIGFPE). */
+    uint64_t span = (uint64_t)((int64_t)max - (int64_t)min) + 1;
+
+    if (span > 0xFFFFFFFFULL) {
+        /* Full 32-bit span: every uint32 is valid, no rejection or modulo. */
+        return (int32_t)((uint32_t)min + (uint32_t)qrng_uint64(ctx));
     }
-    
-    uint32_t threshold = (uint32_t)-range % range;
+
+    uint32_t range = (uint32_t)span;            /* guaranteed nonzero */
+    uint32_t threshold = (0u - range) % range;  /* == 2^32 % range, unbiased */
     uint32_t r;
-    
+
     do {
         r = (uint32_t)qrng_uint64(ctx);
     } while (r < threshold);
-    
-    return min + (r % range);
+
+    /* Unsigned add avoids signed-overflow UB when min<0 and result near max. */
+    return (int32_t)((uint32_t)min + (r % range));
 }
 
 uint64_t qrng_range64(qrng_ctx *ctx, uint64_t min, uint64_t max) {
@@ -428,7 +436,9 @@ uint64_t qrng_range64(qrng_ctx *ctx, uint64_t min, uint64_t max) {
     
     uint64_t range = max - min + 1;
     if (range == 0) {
-        return max;
+        /* range wrapped => full 2^64 span (min==0, max==UINT64_MAX): every
+           uint64 is valid. Return a raw draw, not the constant max. */
+        return qrng_uint64(ctx);
     }
     
     uint64_t threshold = -range % range;


### PR DESCRIPTION
## Summary

`qrng_range32` computes the span `max - min + 1` in signed `int32`. At the full span (`min = INT32_MIN, max = INT32_MAX`) that is signed-overflow UB; at `-O2` the compiler then proves `range != 0` and eliminates the `if (range == 0)` guard, so the subsequent `r % range` divides by zero → **SIGFPE**.

`qrng_range64` has the sibling bug: on the full 2⁶⁴ span the range wraps to `0` (defined, so the guard survives) and it returns the constant `UINT64_MAX` instead of a uniform draw.

This is the standalone-library copy of the same core shipped in Quantum-RNG-API, where the `qrng_range32` bug is reachable as an unauthenticated crash via the `/v1/qrng/range` endpoint (Tsotchke-Corporation/Quantum-RNG-API#1). Same fix, so it can land here without a separate port.

## Fix

- `qrng_range32`: compute the span in 64-bit (`(uint64_t)((int64_t)max - (int64_t)min) + 1`), which cannot overflow; branch out the full-span case (raw draw, no modulo); unsigned-add on return to avoid residual signed overflow when `min < 0`.
- `qrng_range64`: return `qrng_uint64(ctx)` on the full-span (`range == 0`) case.

## Verification

Built and tested with the **real generator** (`qrng_init` + `qrng_range*`) at `-O2`:

- **pre-fix**, `qrng_range32(ctx, INT32_MIN, INT32_MAX)` → `SIGFPE` (exit 136); **post-fix** → no crash, output spans negatives + positives over 3M draws;
- **pre-fix**, `qrng_range64(ctx, 0, UINT64_MAX)` → constant `18446744073709551615`; **post-fix** → draws vary;
- bounded `[-3..6]` all buckets hit, `[1..6]` unaffected, `range64 [100..109]` in range;
- the repo's own suite passes on the patched tree: `make test` (statistical + stress) and `edge_cases_test` ("Range Edge Cases: PASS").

Standalone reproducer available on request.
